### PR TITLE
Check for the OS and change sed args

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -8,6 +8,14 @@ import history
 import files
 import programs
 
+OS <= uname -s
+
+sedArgs = "-r"
+
+if $OS == "Darwin" {
+	sedArgs = "-E"
+}
+
 NASHCOMPLETE_CMD = (
 	("kill" $nash_complete_kill)
 	("systemctl" $nash_complete_systemctl)

--- a/files.sh
+++ b/files.sh
@@ -4,7 +4,7 @@ fn nash_complete_paths(parts, line, pos) {
 	partsz   <= len($parts)
 	last     <= -expr $partsz - 1
 	last     <= trim($last)
-	lastpart <= echo -n $parts[$last] | sed -r "s#^~#"+$HOME+"#g"
+	lastpart <= echo -n $parts[$last] | sed $sedArgs "s#^~#"+$HOME+"#g"
 
 	-test -d $lastpart
 

--- a/kill.sh
+++ b/kill.sh
@@ -73,7 +73,7 @@ fn nash_complete_kill(parts, line, pos) {
 		ps -eo "pid,ppid,user,pcpu,pmem,args"
 						--sort "%mem" |
 		tr -s " " |
-		sed -r "s/^ //g" |
+		sed $sedArgs "s/^ //g" |
 		-fzf --header $pidsHeader
 					--header-lines=1
 					-m


### PR DESCRIPTION
Due to a difference between GNU `sed` and the `sed` command provided by OSX, we need to check the OS before setting arguments. The difference in OSX is described in [this thread](http://stackoverflow.com/questions/7913766/sed-command-works-on-linux-but-not-on-os-x).