### PR TITLE
Changed expr to bc tool

### DIFF
--- a/files.sh
+++ b/files.sh
@@ -2,7 +2,7 @@
 
 fn nash_complete_paths(parts, line, pos) {
 	partsz   <= len($parts)
-	last     <= -expr $partsz - 1
+	last     <= -echo $partsz - 1 | bc
 	last     <= trim($last)
 	lastpart <= echo -n $parts[$last] | sed $sedArgs "s#^~#"+$HOME+"#g"
 


### PR DESCRIPTION
This path fix issue #17 

**expr** is bad dude here! 

When result of expression is 0, **expr** exit status is 1 and **nash** don't set **last** var.

man expr

> Exit status is 0 if EXPRESSION is neither null nor 0, 1 if EXPRESSION is null or 0, 2  if  EXPRESSION  is  syntactically invalid, and 3 if an error occurred.